### PR TITLE
Keep selected sensors highlighted in list

### DIFF
--- a/src/Extensions/Sensors/SensorDetailExtension.ts
+++ b/src/Extensions/Sensors/SensorDetailExtension.ts
@@ -9,6 +9,29 @@ export default class SensorDetailExtension extends SensorExtension {
     private currentSensorID: SensorID | null = null;
     private dataView: HistoricalDataView | null = null;
 
+    private handleTimeUpdate = () => this.updateCursor();
+    private handleSensorSelected = (sensorId: SensorID) => {
+        console.log("🔍 Sensor Selected:", sensorId);
+
+        if (!this.dataView) {
+            console.warn("⚠️ No dataView available!");
+            return;
+        }
+
+        if (!this.dataView.getSensors().has(sensorId)) {
+            console.warn(`⚠️ Sensor ${sensorId} not found in dataView`);
+            return;
+        }
+
+        this.currentSensorID = sensorId;
+        this.updateCharts();
+    };
+
+    private handleDeselected = () => {
+        this.currentSensorID = null;
+        this.panel?.clear();
+    };
+
     init(): void {
         super.init();
         this.panel = new SensorDetailPanel();
@@ -17,28 +40,10 @@ export default class SensorDetailExtension extends SensorExtension {
         // ✅ Fetch sensor data
         this.dataView = getSensorData();
 
-        // ✅ Update charts every second
-        eventBus.on("timeUpdate", () => {
-            this.updateCursor();
-        });
-
-        // ✅ Update when selecting a sensor
-        eventBus.on("sensorSelected", (sensorId: SensorID) => {
-            console.log("🔍 Sensor Selected:", sensorId);
-
-            if (!this.dataView) {
-                console.warn("⚠️ No dataView available!");
-                return;
-            }
-
-            if (!this.dataView.getSensors().has(sensorId)) {
-                console.warn(`⚠️ Sensor ${sensorId} not found in dataView`);
-                return;
-            }
-
-            this.currentSensorID = sensorId;
-            this.updateCharts();
-        });
+        // ✅ Event listeners
+        eventBus.on("timeUpdate", this.handleTimeUpdate);
+        eventBus.on("sensorSelected", this.handleSensorSelected);
+        eventBus.on("deselect", this.handleDeselected);
 
         console.log("📋 Sensor Detail Extension Initialized.");
     }
@@ -102,7 +107,8 @@ export default class SensorDetailExtension extends SensorExtension {
             this.panel = null;
         }
 
-        eventBus.off("timeUpdate", this.updateCursor);
-        eventBus.off("sensorSelected", this.updateCharts);
+        eventBus.off("timeUpdate", this.handleTimeUpdate);
+        eventBus.off("sensorSelected", this.handleSensorSelected);
+        eventBus.off("deselect", this.handleDeselected);
     }
 }

--- a/src/Extensions/Sensors/SensorDetailPanel.ts
+++ b/src/Extensions/Sensors/SensorDetailPanel.ts
@@ -152,6 +152,14 @@ export default class SensorDetailPanel extends UIBasePanel {
         return gradient;
     }
 
+    // ✅ Clear all charts when sensor is deselected
+    clear(): void {
+        this.charts.forEach(chart => chart.destroy());
+        this.charts.clear();
+        this.content.innerHTML = "";
+        this.setTitle("Sensor Details");
+    }
+
     // ✅ Auto-update the chart with new data points every second
     updateCursor(sensorId: string, sensorData: any): void {
         console.log(`🔄 Updating cursor for sensor: ${sensorId}`);

--- a/src/Extensions/Sensors/SensorListPanel.ts
+++ b/src/Extensions/Sensors/SensorListPanel.ts
@@ -1,6 +1,6 @@
 import UIBasePanel from "../UI/Panel/UIBasePanel";
 import {getSensorData} from "./sensorUtils";
-import {HistoricalDataView} from "./HistoricalDataView";
+import {HistoricalDataView, SensorID} from "./HistoricalDataView";
 import eventBus from "./../../modules/Events.ts"; // ✅ Ensure Events are used
 
 export default class SensorListPanel extends UIBasePanel {
@@ -18,9 +18,10 @@ export default class SensorListPanel extends UIBasePanel {
             {title: "Sensor", field: "sensor"},
             {title: "Group", field: "group"},
         ]);
-        this.initializeOutsideClickListener();
         // ✅ Populate Initial Data
         this.populateTable(this.getSensorData());
+
+        this.initializeEventBusListeners();
     }
 
     private getSensorData() {
@@ -45,19 +46,27 @@ export default class SensorListPanel extends UIBasePanel {
         console.log(`📌 Sensor Selected from Table: ${sensorId}`);
         super.onRowClicked(row);
         eventBus.emit("sensorSelected", sensorId);
-
     }
 
-    private initializeOutsideClickListener() {
-        document.addEventListener("click", (event) => {
-            const isClickInsideTable = this.container.contains(event.target as Node);
+    private initializeEventBusListeners(): void {
+        eventBus.on("sensorSelected", (sensorId: SensorID) => this.highlightSensor(sensorId));
+        eventBus.on("deselect", () => this.clearSelection());
+    }
 
-            if (!isClickInsideTable && this.selectedRow) {
-                this.selectedRow.style.backgroundColor = ""; // ✅ Reset Highlight
-                this.selectedRow = null; // ✅ Clear Selection
-                console.log("🔄 Deselected Sensor");
-            }
-        });
+    private highlightSensor(sensorId: SensorID): void {
+        if (!this.table) return;
+        const row = this.table.querySelector<HTMLTableRowElement>(`tr[data-sensor-id="${sensorId}"]`);
+        if (!row) return;
+
+        super.onRowClicked(row); // Highlight without re-emitting event
+    }
+
+    private clearSelection(): void {
+        if (this.selectedRow) {
+            this.selectedRow.style.backgroundColor = "";
+            this.selectedRow = null;
+            console.log("🔄 Deselected Sensor");
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- Ensure sensor list rows stay highlighted based on global selection events
- Reset sensor detail charts when sensors are deselected
- Listen for deselection to clear the detail panel and list highlight

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f8a7b05a4832493b460883bbb2245